### PR TITLE
chore: modules

### DIFF
--- a/Colorized.lean
+++ b/Colorized.lean
@@ -1,4 +1,8 @@
+module
+
 namespace Colorized
+
+public section
 
 /-! Colorized library for adding color and style to text output. This library provides functionality
 to change the foreground and background colors, as well as to apply various text styles. -/
@@ -64,19 +68,33 @@ class Colorized (α : Type) where
   bgColor := colorize Section.Background
   color := colorize Section.Foreground
 
+end
+
+namespace Colorized
+
+
 /-- Constant string representing the beginning of an ANSI escape sequence. -/
 private def const := "\x1b["
 
 /-- Constant string for resetting text formatting. -/
 private def reset := "\x1b[0m"
 
-instance : Colorized String where
-  colorize sec col str :=
-    let sectionNum :=
-      match sec with
-      | Section.Foreground => "9"
-      | Section.Background => "4"
-    s!"{const}{sectionNum}{repr col}m{str}{reset}"
+/-- Applies a section/color to a string. -/
+@[inline]
+public def colorizeString (sec : Section) (col : Color) (str : String) : String :=
+  let secNum :=
+    match sec with
+    | .Foreground => "9"
+    | .Background => "4"
+  s!"{const}{secNum}{repr col}m{str}{reset}"
 
-  style sty str :=
-    s!"{const}{repr sty}m{str}{reset}"
+/-- Applies a style to a string. -/
+@[inline]
+public def stylizeString (sty : Style) (str : String) : String :=
+  s!"{const}{repr sty}m{str}{reset}"
+
+end Colorized
+
+public instance : Colorized String where
+  colorize := Colorized.colorizeString
+  style := Colorized.stylizeString

--- a/Colorized.lean
+++ b/Colorized.lean
@@ -70,9 +70,6 @@ class Colorized (α : Type) where
 
 end
 
-namespace Colorized
-
-
 /-- Constant string representing the beginning of an ANSI escape sequence. -/
 private def const := "\x1b["
 
@@ -92,8 +89,6 @@ public def colorizeString (sec : Section) (col : Color) (str : String) : String 
 @[inline]
 public def stylizeString (sty : Style) (str : String) : String :=
   s!"{const}{repr sty}m{str}{reset}"
-
-end Colorized
 
 public instance : Colorized String where
   colorize := Colorized.colorizeString

--- a/Example.lean
+++ b/Example.lean
@@ -1,7 +1,9 @@
+module
+
 import «Colorized»
 open Colorized
 
-def main : IO Unit := do
+public def main : IO Unit := do
   -- | Simple style
   IO.println (Colorized.style Style.Underline "Hello, world!")
 


### PR DESCRIPTION
Switch to [lean modules](https://lean-lang.org/doc/reference/latest/Source-Files-and-Modules/#module-scopes).

Currently, a file cannot be a module if it imports non-modules-sources such as *colorized*'s, so this PR makes *colorized* importable by module files.

The only change in the API is the introduction of public functions `Colorized.colorizeString` and `Colorized.stylizeString`. Public `Colorized String` instance was using private definitions `Colorized.const` and `Colorized.reset` directly, which modules do not allow currently. The public instance now uses these two new functions so that `const` and `reset` can stay private.